### PR TITLE
Changed Life Stock in Landstalkers, Fixed Zillion, and Added mcguffin tags to all 3 of those games

### DIFF
--- a/worlds/Landstalker - The Treasures of King Nole/progression.txt
+++ b/worlds/Landstalker - The Treasures of King Nole/progression.txt
@@ -51,7 +51,7 @@ Short Cake: useful
 Gola's Nail: progression
 Gola's Horn: progression
 Gola's Fang: progression
-Life Stock: filler
+Life Stock: progression
 No Item: filler
 1 Gold: filler
 20 Golds: filler

--- a/worlds/Landstalker - The Treasures of King Nole/progression.txt
+++ b/worlds/Landstalker - The Treasures of King Nole/progression.txt
@@ -30,12 +30,12 @@ Statue of Jypta: useful
 Sun Stone: progression
 Armlet: progression
 Einstein Whistle: progression
-Blue Jewel: progression
-Yellow Jewel: progression
+Blue Jewel: mcguffin
+Yellow Jewel: mcguffin
 Lithograph: progression
-Red Jewel: progression
+Red Jewel: mcguffin
 Pawn Ticket: useful
-Purple Jewel: progression
+Purple Jewel: mcguffin
 Gola's Eye: progression
 Death Statue: filler
 Dahl: filler
@@ -45,12 +45,12 @@ Oracle Stone: progression
 Idol Stone: progression
 Key: progression
 Safety Pass: progression
-Green Jewel: progression
+Green Jewel: mcguffin
 Bell: useful
 Short Cake: useful
-Gola's Nail: progression
-Gola's Horn: progression
-Gola's Fang: progression
+Gola's Nail: mcguffin
+Gola's Horn: mcguffin
+Gola's Fang: mcguffin
 Life Stock: progression
 No Item: filler
 1 Gold: filler

--- a/worlds/Toontown/progression.txt
+++ b/worlds/Toontown/progression.txt
@@ -73,11 +73,11 @@ Lawbot Disguise: progression
 TTC Access Key: progression
 +2 Laff Boost: progression
 Organic Toon-Up Upgrade: useful
-Defeated Cashbot CFO: progression
+Defeated Cashbot CFO: mcguffin
 20% Gag XP Bundle: filler
-Bounty: progression
-Defeated Lawbot CJ: progression
-Defeated Bossbot CEO: progression
+Bounty: mcguffin
+Defeated Lawbot CJ: mcguffin
+Defeated Bossbot CEO: mcguffin
 Dollar Mint Key: progression
 Organic Squirt Upgrade: useful
-Defeated Sellbot VP: progression
+Defeated Sellbot VP: mcguffin

--- a/worlds/Zillion/progression.txt
+++ b/worlds/Zillion/progression.txt
@@ -7,5 +7,5 @@ JJ: progression
 Opa-Opa: progression
 Apple: progression
 Empty: filler
-Red ID Card: progression
+Red ID Card: mcguffin
 Champ: progression

--- a/worlds/Zillion/progression.txt
+++ b/worlds/Zillion/progression.txt
@@ -1,5 +1,5 @@
 ID Card: filler
-Floppy Disk: useful
+Floppy Disk: progression
 Zillion: useful
 Scope: useful
 Bread: filler

--- a/worlds/Zillion/progression.txt
+++ b/worlds/Zillion/progression.txt
@@ -1,6 +1,6 @@
 ID Card: filler
 Floppy Disk: progression
-Zillion: useful
+Zillion: progression
 Scope: useful
 Bread: filler
 JJ: progression

--- a/worlds/Zillion/progression.txt
+++ b/worlds/Zillion/progression.txt
@@ -1,5 +1,5 @@
 ID Card: filler
-Floppy Disk: progression
+Floppy Disk: mcguffin
 Zillion: progression
 Scope: useful
 Bread: filler


### PR DESCRIPTION
Having 15 Life Stocks in Landstalkers is required for a check so it probably should be progression imo and there are some classified as such.

I also fixed a misclick I did with zillion floppy disk those are supposed to be progression as thats the main mcguffin