### PR TITLE
Manual

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /old output/*.txt
 !/old output/placeholder.txt
+/input/*.apworld

--- a/import_manual_apworld.py
+++ b/import_manual_apworld.py
@@ -1,0 +1,47 @@
+import os
+import json
+import zipfile
+
+from os import listdir
+from os.path import isfile, join
+
+abspath = os.path.dirname(__file__)
+input_folder = abspath+ "\\input"
+world_folder = abspath+ "\\worlds"
+
+InputApworlds = [f for f in listdir(input_folder) if isfile(join(input_folder, f)) and f.lower().startswith("manual_")]
+
+for manual in InputApworlds:
+    fname = os.path.join(input_folder, manual)
+    archive = zipfile.ZipFile(fname, 'r')
+    dirs = list(set([os.path.dirname(x) for x in archive.namelist()]))
+    top_dir = dirs[0].split('/')[0]
+    gamedata = json.load(archive.open(f'{top_dir}/data/game.json'))
+    items = json.load(archive.open(f'{top_dir}/data/items.json'))
+
+    game_name = f"Manual_{gamedata['game']}_{gamedata.get('creator',gamedata.get('player'))}"
+    game_folder = os.path.join(world_folder, game_name)
+    if not os.path.exists(game_folder):
+        os.makedirs(game_folder)
+
+    game_file = os.path.join(game_folder, "progression.txt")
+
+    with open(game_file, "w+", encoding="utf-8") as f:
+        default_filler = gamedata.get('filler_item_name', '')
+        if default_filler:
+            f.write(f"{gamedata['filler_item_name']}: filler\n")
+        for item in items:
+            if default_filler and item['name'] == default_filler:
+                continue
+            classification = "filler"
+            if item.get("trap"):
+                classification = "trap"
+            elif item.get("progression_skip_balancing"):
+                classification = "mcguffin"
+            elif item.get("progression"):
+                classification = "progression"
+            elif item.get("useful"):
+                classification = "useful"
+            f.write(f"{item['name']}: {classification}\n")
+    archive.close()
+print("wow")

--- a/worlds/Manual_HardspaceShipbreaker_Rubik/progression.txt
+++ b/worlds/Manual_HardspaceShipbreaker_Rubik/progression.txt
@@ -1,0 +1,15 @@
+Filler: filler
+Mackerel Light Cargo: progression
+Mackerel Station Hopper: progression
+Mackerel Heavy Cargo: progression
+Mackerel Exolab: progression
+Atlas Nomad Cargo Hauler: progression
+Atlas Scout Patrol Craft: progression
+Atlas Roustabout Tug: progression
+Javelin Heavy Cargo: progression
+Javelin Tanker: progression
+Gecko Station Hopper: progression
+Gecko Heavy Cargo: progression
+Gecko Salvage Runner: progression
+Gecko Stargazer: progression
+LYNX Completion Points: progression

--- a/worlds/Manual_PowerwashSimulator_hallojasper/progression.txt
+++ b/worlds/Manual_PowerwashSimulator_hallojasper/progression.txt
@@ -1,186 +1,247 @@
-Progressive Prime Vista 1500 Nozzle: progression
 Dirt: filler
-Mayor's Mansion Fence: progression
-Progressive Prime Vista 1500 Extension: progression
-Completion Star Parts Mode: progression
-Progressive Prime Vista 3000 Extension: progression
-Scaffolding Floor: progression
-Fire Helicopter Water Tank: progression
-Fire Helicopter Body: progression
-Recreation Vehicle Accesories: progression
-Back Garden Miscellaneous: progression
-Playground Tall Tower Playthings: progression
-Monster Truck Miscellaneous: progression
-Ferris Wheel Fences: progression
-Bungalow Porch: progression
-Subway Platform Benches: progression
-Golf Cart Roof: progression
-Monster Truck Cat Head: progression
-Shoe House Roof: progression
-Tree House Lower Deck: progression
-Bungalow Entry: progression
-Ferris Wheel Miscellaneous: progression
-Subway Platform Walls: progression
-Dirt Bike Engine: progression
-Shoe House Windows: progression
-Skatepark Stunt Parts: progression
-Ladder Length: progression
-Mayor's Mansion Walls: progression
+Progressive Prime Vista 1500 Nozzle: progression
 Progressive Prime Vista 3000 Nozzle: progression
-Playground Inner Floor: progression
-Grandpa Miller's Car Lights: progression
-Tree House Playground: progression
-Playground Outer Floor: progression
-Golf Cart Miscellaneous: progression
-Mayor's Mansion Roof: progression
-Vintage Car Doors: progression
-Frolic Boat Accesories: progression
-Dirt Bike Miscellaneous: progression
-Tree House Miscellaneous: progression
-Vintage Car Tyres: progression
-Tree House Upper Deck: progression
-Tree House Walls: progression
 Progressive Urban X U2 Nozzle: progression
-Ferris Wheel Star: progression
-Bungalow Roof: progression
-Skatepark Floors: progression
-Back Garden Patio: progression
-Playground Bridges: progression
-Golf Cart Tyres: progression
-Back Garden Shed: progression
-Playground Miscellaneous: progression
-Vintage Car Roof: progression
-Dirt Bike Wheels: progression
-Playground Lower Tower: progression
-Subway Platform Lights: progression
-Back Garden Barbeque: progression
-Stunt Plane Engine: progression
-Playground Short Tower Playthings: progression
 Progressive Prime Vista PRO Nozzle: progression
-Mayor's Mansion Main Gate: progression
-Fire Truck Tyres: progression
-Back Garden Fence: progression
-Vintage Car Body: progression
-Ferris Wheel Platform: progression
-Stunt Plane Rear Wings: progression
-Grandpa Miller's Car Miscellaneous: progression
-Monster Truck Hatches: progression
-Back Garden Swing Sofa: progression
-Frolic Boat Underside: progression
-Monster Truck Sides: progression
-Recreation Vehicle Lower Body: progression
-Washroom Water: progression
-Ferris Wheel Supports: progression
-Penny Farthing Frame: progression
+Progressive Prime Vista 1500 Extension: progression
+Progressive Prime Vista 3000 Extension: progression
+Progressive Urban X U2 Extension: progression
 Progressive Prime Vista PRO Extension: progression
-Motorbike and Sidecar Frame: progression
+Stepstool: progression
+Ladder Length: progression
+Scaffolding Floor: progression
+Completion Star Parts Mode: progression
+Completion Star Percentage Mode: progression
+Van Tyres: progression
+Van Windows: progression
+Van Body: progression
+Van Lights: progression
+Van: progression
+Vintage Car Tyres: progression
+Vintage Car Body: progression
+Vintage Car Doors: progression
+Vintage Car Accesories: progression
+Vintage Car Roof: progression
+Vintage Car Front: progression
+Vintage Car: progression
+Golf Cart Roof: progression
+Golf Cart Tyres: progression
+Golf Cart Body: progression
+Golf Cart Miscellaneous: progression
+Golf Cart: progression
+Recreation Vehicle Tyres: progression
+Recreation Vehicle Lights: progression
+Recreation Vehicle Lower Body: progression
+Recreation Vehicle Windows: progression
+Recreation Vehicle Upper Body: progression
+Recreation Vehicle Accesories: progression
+Recreation Vehicle: progression
+Drill Front: progression
+Drill Tracks: progression
+Drill Shielding: progression
+Drill Door: progression
+Drill: progression
+Frolic Boat Underside: progression
+Frolic Boat Floor: progression
+Frolic Boat Controls: progression
+Frolic Boat Doors: progression
+Frolic Boat Cabin Walls: progression
+Frolic Boat Canopy: progression
+Frolic Boat Accesories: progression
+Frolic Boat: progression
+Stunt Plane Wheels: progression
+Stunt Plane Engine: progression
+Stunt Plane Rear Wings: progression
+Stunt Plane Lower Wings: progression
+Stunt Plane Upper Wing: progression
+Stunt Plane Cockpit: progression
+Stunt Plane: progression
+Back Garden Pond: progression
+Back Garden Steps: progression
+Back Garden Patio: progression
+Back Garden Table: progression
+Back Garden Fence: progression
+Back Garden Dog House: progression
+Back Garden Swing Sofa: progression
+Back Garden Shed: progression
+Back Garden Barbeque: progression
+Back Garden Miscellaneous: progression
+Back Garden: progression
+Mayor's Mansion Fence: progression
+Mayor's Mansion Garage: progression
+Mayor's Mansion Main Gate: progression
+Mayor's Mansion Roof: progression
+Mayor's Mansion Door: progression
+Mayor's Mansion Walls: progression
+Mayor's Mansion: progression
+Detached House Garage: progression
+Detached House Porch: progression
+Detached House Veranda: progression
+Detached House Walls: progression
+Detached House Roof: progression
+Detached House Miscellaneous: progression
+Detached House: progression
+Fire Helicopter Tail: progression
+Fire Helicopter Water Tank: progression
+Fire Helicopter Landing Gear: progression
+Fire Helicopter Engine: progression
 Fire Helicopter Hydraulics: progression
-Washroom Doors: progression
-Motorbike and Sidecar Lights: progression
+Fire Helicopter Body: progression
+Fire Helicopter: progression
+Dirt Bike Wheels: progression
+Dirt Bike Front: progression
+Dirt Bike Frame: progression
+Dirt Bike Engine: progression
+Dirt Bike Miscellaneous: progression
+Dirt Bike: progression
+Playground Outer Floor: progression
+Playground Inner Floor: progression
+Playground Roundabout: progression
+Playground Bridges: progression
+Playground Lower Tower: progression
+Playground Upper Tower: progression
+Playground Short Tower Playthings: progression
+Playground Tall Tower Playthings: progression
+Playground Miscellaneous: progression
+Playground: progression
+Tree House Lower Deck: progression
+Tree House Middle Deck: progression
+Tree House Upper Deck: progression
+Tree House Barbeque: progression
+Tree House Playground: progression
 Tree House Stairs: progression
 Tree House Tables: progression
-Recreation Vehicle Tyres: progression
-Subway Platform Miscellaneous: progression
-Motorbike and Sidecar Miscellaneous: progression
-Recreation Vehicle Lights: progression
-Fire Truck Windows: progression
-Frolic Boat Canopy: progression
-Dirt Bike Frame: progression
-Grandpa Miller's Car Windows: progression
-Mayor's Mansion Garage: progression
-Frolic Boat Floor: progression
-Skatepark Walls: progression
-Progressive Urban X U2 Extension: progression
-Fire Truck Miscellaneous: progression
-Mayor's Mansion Door: progression
-Fire Truck Body: progression
-Washroom Floor: progression
-Back Garden Steps: progression
 Tree House Roof: progression
-Ferris Wheel Wiring: progression
-Vintage Car Front: progression
-Back Garden Pond: progression
-Stunt Plane Wheels: progression
-Playground Roundabout: progression
-Recreation Vehicle Windows: progression
-Golf Cart Body: progression
-Playground Upper Tower: progression
-Detached House Porch: progression
-Vintage Car Accesories: progression
-Grandpa Miller's Car Wheels: progression
-Fire Truck Lights: progression
-Dirt Bike Front: progression
-Penny Farthing Steering: progression
-Washroom Walls: progression
-Shoe House Shoe: progression
-Stunt Plane Cockpit: progression
-Subway Platform Doors: progression
-Frolic Boat Controls: progression
-Subway Platform Ceilings: progression
-Washroom Miscellaneous: progression
-Motorbike and Sidecar Sidecar: progression
-Frolic Boat Cabin Walls: progression
-Fire Helicopter Landing Gear: progression
-Back Garden Table: progression
 Tree House Door: progression
-Frolic Boat Doors: progression
-Detached House Roof: progression
-Detached House Walls: progression
-Skatepark Floor Transitions: progression
-Washroom Urinals: progression
-Motorbike and Sidecar Tyres: progression
-Grandpa Miller's Car Body: progression
-Detached House Miscellaneous: progression
-Washroom Ceiling: progression
-Back Garden Dog House: progression
-Stunt Plane Upper Wing: progression
-Fire Helicopter Tail: progression
-Washroom Toilets: progression
-Drill Door: progression
-Stunt Plane Lower Wings: progression
-Recreation Vehicle Upper Body: progression
-Monster Truck Underside: progression
-Tree House Middle Deck: progression
-Subway Platform Floors: progression
-Shoe House Door: progression
-Monster Truck Tyres: progression
-Drill Tracks: progression
-Monster Truck Windows: progression
-Detached House Veranda: progression
-Drill Shielding: progression
-Tree House Barbeque: progression
-Fire Helicopter Engine: progression
-Bungalow Walls: progression
-Ferris Wheel Spokes: progression
-Monster Truck Rear: progression
-Subway Platform Screens: progression
-Motorbike and Sidecar Engine: progression
-Stepstool: progression
-Detached House Garage: progression
-Drill Front: progression
-Monster Truck Cat Body: progression
-Fire Helicopter: progression
-Completion Star Percentage Mode: progression
-Vintage Car: progression
-Back Garden: progression
-Frolic Boat: progression
-Stunt Plane: progression
-Recreation Vehicle: progression
-Fire Truck: progression
-Shoe House: progression
-Grandpa Miller's Car: progression
-Motorbike and Sidecar: progression
-Ferris Wheel: progression
-Detached House: progression
-Penny Farthing: progression
-Playground: progression
-Bungalow: progression
-Washroom: progression
+Tree House Walls: progression
+Tree House Miscellaneous: progression
 Tree House: progression
-Mayor's Mansion: progression
-Dirt Bike: progression
-Golf Cart: progression
-Subway Platform: progression
-Drill: progression
-Skatepark: progression
+Washroom Urinals: progression
+Washroom Toilets: progression
+Washroom Floor: progression
+Washroom Doors: progression
+Washroom Walls: progression
+Washroom Ceiling: progression
+Washroom Water: progression
+Washroom Miscellaneous: progression
+Washroom: progression
+Monster Truck Tyres: progression
+Monster Truck Cat Head: progression
+Monster Truck Cat Body: progression
+Monster Truck Hatches: progression
+Monster Truck Windows: progression
+Monster Truck Sides: progression
+Monster Truck Rear: progression
+Monster Truck Miscellaneous: progression
+Monster Truck Underside: progression
 Monster Truck: progression
+Ferris Wheel Wiring: progression
+Ferris Wheel Platform: progression
+Ferris Wheel Fences: progression
+Ferris Wheel Spokes: progression
+Ferris Wheel Star: progression
+Ferris Wheel Supports: progression
+Ferris Wheel Miscellaneous: progression
+Ferris Wheel: progression
+Bungalow Porch: progression
+Bungalow Roof: progression
+Bungalow Walls: progression
+Bungalow Entry: progression
+Bungalow: progression
+Penny Farthing Frame: progression
+Penny Farthing Steering: progression
+Penny Farthing: progression
+Grandpa Miller's Car Lights: progression
+Grandpa Miller's Car Body: progression
+Grandpa Miller's Car Windows: progression
+Grandpa Miller's Car Wheels: progression
+Grandpa Miller's Car Miscellaneous: progression
+Grandpa Miller's Car: progression
+Subway Platform Floors: progression
+Subway Platform Ceilings: progression
+Subway Platform Lights: progression
+Subway Platform Walls: progression
+Subway Platform Doors: progression
+Subway Platform Screens: progression
+Subway Platform Benches: progression
+Subway Platform Miscellaneous: progression
+Subway Platform: progression
+Motorbike and Sidecar Tyres: progression
+Motorbike and Sidecar Sidecar: progression
+Motorbike and Sidecar Lights: progression
+Motorbike and Sidecar Engine: progression
+Motorbike and Sidecar Frame: progression
+Motorbike and Sidecar Miscellaneous: progression
+Motorbike and Sidecar: progression
+Skatepark Walls: progression
+Skatepark Floors: progression
+Skatepark Floor Transitions: progression
+Skatepark Stunt Parts: progression
+Skatepark: progression
+Fire Truck Miscellaneous: progression
+Fire Truck Lights: progression
+Fire Truck Windows: progression
+Fire Truck Body: progression
+Fire Truck Tyres: progression
+Fire Truck: progression
+Shoe House Roof: progression
+Shoe House Windows: progression
+Shoe House Door: progression
+Shoe House Shoe: progression
+Shoe House: progression
+SUV Lights: progression
+SUV Windows: progression
+SUV Body: progression
+SUV Tyres: progression
+SUV: progression
+Fortune Teller's Wagon Bay Windows: progression
+Fortune Teller's Wagon Skylight: progression
+Fortune Teller's Wagon Storage: progression
+Fortune Teller's Wagon Table: progression
+Fortune Teller's Wagon Decorations: progression
+Fortune Teller's Wagon Door: progression
+Fortune Teller's Wagon Underside: progression
+Fortune Teller's Wagon Entry: progression
+Fortune Teller's Wagon Walls: progression
+Fortune Teller's Wagon Roof: progression
+Fortune Teller's Wagon: progression
+Ancient Monument Phalanges: progression
+Ancient Monument Arm: progression
+Ancient Monument Hand: progression
+Ancient Monument: progression
+Ancient Statue Helmet Slabs: progression
+Ancient Statue Helmet Decoration: progression
+Ancient Statue Head: progression
+Ancient Statue Torso: progression
+Ancient Statue Neck: progression
+Ancient Statue Arm: progression
+Ancient Statue: progression
+Recreational Vehicle Again Landing Gear: progression
+Recreational Vehicle Again Saucers: progression
+Recreational Vehicle Again Tractor Beam: progression
+Recreational Vehicle Again Gyromagnetic Discs: progression
+Recreational Vehicle Again Gravity Plating: progression
+Recreational Vehicle Again Engine: progression
+Recreational Vehicle Again Miscellaneous: progression
+Recreational Vehicle Again: progression
+Fishing Boat Anchor: progression
+Fishing Boat Hull: progression
+Fishing Boat Main Deck: progression
+Fishing Boat Cabin: progression
+Fishing Boat Bridge: progression
+Fishing Boat Roof: progression
+Fishing Boat Mast: progression
+Fishing Boat Storage: progression
+Fishing Boat Miscellaneous: progression
+Fishing Boat: progression
+Forest Cottage Back Dormer: progression
+Forest Cottage Back Gable: progression
+Forest Cottage Front Dormer: progression
+Forest Cottage Front Gable: progression
+Forest Cottage Front Wall: progression
+Forest Cottage Fence: progression
+Forest Cottage Side Gable: progression
+Forest Cottage Main Roof: progression
+Forest Cottage Walls: progression
+Forest Cottage Foundation: progression
+Forest Cottage: progression

--- a/worlds/Manual_Warehouse_Alexander230/progression.txt
+++ b/worlds/Manual_Warehouse_Alexander230/progression.txt
@@ -1,5 +1,1022 @@
-Wyrmguard Shield: filler
+Nothing: filler
+Vault Key: progression
+Key for Storage Room 01: progression
+Key for Storage Room 02: progression
+Key for Storage Room 03: progression
+Key for Storage Room 04: progression
+Key for Storage Room 05: progression
+Key for Storage Room 06: progression
+Key for Storage Room 07: progression
+Key for Storage Room 08: progression
+Key for Storage Room 09: progression
+Key for Storage Room 10: progression
+Key for Storage Room 11: progression
+Key for Storage Room 12: progression
+Key for Storage Room 13: progression
+Key for Storage Room 14: progression
+Key for Storage Room 15: progression
+Key for Storage Room 16: progression
+Key for Storage Room 17: progression
+Key for Storage Room 18: progression
+Key for Storage Room 19: progression
+Key for Storage Room 20: progression
+Ancient Runestone Scroll: filler
+Moss of Desert Thriving: filler
+Shimmering Scale Armor: filler
+Vesper's Kiss Perfume: filler
+Cosmic Cereal Box: filler
+Mimosa of Boldness Induction: filler
+Golden Lasso of Truth: filler
+Disguise Me Maybe Cloak: filler
+Zany Zebra Zipper Pouch: filler
+Alien Abductee Alarm Clock: filler
+Stormsurge Boots: filler
+Arcane Gauntlets of Protection: filler
+Unstable Ukelele Wand: filler
+Kitten Karate Gauntlets: filler
+Robo-Raccoon Repair Kit: filler
+Confusion Conch Shell: filler
+Quantum Physics Puzzle Box: filler
+Infinite Socks of Wonder: filler
+Talisman of the Elements: filler
+Starlight Seraph Wings: filler
+Rye of Whiskey Aversion: filler
+Fiery Fiddle Case: filler
+Caffeine Bomb: filler
+Thunderhoof Shield: filler
+Unpredictable Portal Gun: filler
+Invisible Elephant Earpiece: filler
+Kite Surfboard: filler
+Glitter Bomb of Surprise: filler
+Rocket Fuel Coffee Beans: filler
+Mystery Meat Steak: filler
+Golden Griffin's Claw Talisman: filler
+Lobster of Vegetarianism: filler
+Blueberry of Color Blindness: filler
+Dwarven Pickaxe: filler
+Donut of Power: filler
+Lime of Bitter Tanginess: filler
+Bouncy Castle Shield: filler
+Gloopernuts of Confusion: filler
+Fae Feather Tiara: filler
+Overpriced Bubble Wrap: filler
+Instant Noodle Soup of Regret: filler
+Frostbite Shield: filler
+Pixelated Pizza Shield: filler
+Laser Pointer Whip: filler
+Robot Rockstar Rhythm Stick: filler
+Enchanted Quill: filler
+Peculiar Pocket Lint: filler
+Matches of Fire Extinguishing: filler
+Ohm's Law Gauntlets: filler
+Furry Flare Gun: filler
+Whispering Walls Scroll of Knowledge: filler
+Reality Distortion Field: filler
+Flustered Feather Boa: filler
+Starlight Chariot: filler
+Unholy Union Sword: filler
+Robot Reboot Juice Boxes: filler
+Moonwhisper Cloak of Stealth: filler
+Quantum Taco: filler
+Randomized Razzle Dazzle Rifle: filler
+Laser Pointer of Truth: filler
+Time Traveler's Tinfoil Hat: filler
+Arcane Amulet of Protection: filler
+Mystery Meat of Power: filler
+Enchanted Elixir Flask: filler
+Quantum Karaoke Machine: filler
+Elven Longbow: filler
+Blackberry of Thornless Bushes: filler
+Jumbled Jester's Hat: filler
+Corgi Treat Dispenser: filler
+Portobello of Miniaturization: filler
+Rocket Fuel Energy Drink: filler
+Mirthful Magic Wand: filler
+Crazypants Boots: filler
+Rambunctious Rabbit Food: filler
+Robot Uprising Disks: filler
+Kale of Junk Food Cravings: filler
+Healing Hands of the Ancients: filler
+Misty Mirrored Shield: filler
+Sneeze Guard Helmet: filler
+Elixir of Life and Death: filler
+Crazy Hairdo of Chaos: filler
+Dragon's Tooth Amulet: filler
+Astral Amulet of Protection: filler
+Dragon's Breath Dagger: filler
+Verdant Vial of Vigor: filler
+Quirky Questing Gloves: filler
+Portal to Nowhere Keycard: filler
+Chicken Nuggets: filler
+Elemental Earpiece of Elemental Awareness: filler
+Giant Slingshot Shot: filler
+Crystal Orb of Power: filler
+Confused Cat Whisker Wand: filler
+Cooking Pot of Raw Cuisine: filler
+Elixir of Elysium: filler
+Nightshade Wand: filler
+Pocket Lint of Protection: filler
+Wysteria's Song Lute: filler
+Ninja Training Wheels: filler
+Sassy Boots: filler
+Moonlit Memento Box: filler
+Confusion Grenade: filler
+Holey Grail Amulet: filler
+Raven's Wings: filler
+Taco Tuesday Box: filler
+Quantum Q-Tip Generators: filler
+Spellbound Chalice of Life: filler
+Dreamcatcher's Chalice: filler
+Quantum Leapfrog Board: filler
+Raven's Feather Cape: filler
+Furry Fuzz Bomb: filler
+Silverberry of Lead Heaviness: filler
+Terraverde Gauntlets: filler
+Crimson Cloak of Shadows: filler
+Elixir of Eldrador: filler
+Dragon's Tooth Ring: filler
+Celestial Chronicle Scroll: filler
+Celestial Mapstone: filler
+Razzle Dazzle Sword: filler
+Feline Fury Cape: filler
+Unicorn Horns: filler
+Quill of the Ancients: filler
+Giant Marshmallow Gun: filler
+Fiendish Fork of Despair: filler
+Confusion Confectionery Box: filler
+Disguise as a Potted Plant: filler
+Starweaver's Web Scepter: filler
+Time Warp Tonic: filler
+Unicorn Fart of Confusion: filler
+Runebound Scroll: filler
+Fuzzy Socks of Comfort: filler
 Mithril Brooch: filler
-Nightshade Tome: filler
-Superfluous Sausage Ring: filler
+Pogo Stick of Jump: filler
+Whispering Walls Scroll: filler
+Wacky Wig Helmet: filler
+Frostbite Focus Crystal: filler
+Nightshade Gloves: filler
+Whimsy Waffle Iron: filler
+Elemental Amulet of Fire: filler
+Invisibility Socks: filler
+Flying Fuzzy Slippers: filler
+Forgotten Sandwich Wrapper: filler
+Ridiculous Rocket Fuel: filler
+Thunderstruck Helm: filler
+Whispering Winds Wand of the Elements: filler
+Frostbite Dagger: filler
+Wizard's Tower Blueprint: filler
+Robot Uprising Whistle: filler
+Soapberry of Dirt Attraction: filler
+Deerberry of Predator Attraction: filler
+Intergalactic Snack Box: filler
+Whispering Winds Tome: filler
+Staff of Misdirection: filler
+Mythic Helm: filler
+Arcane Crystal Cluster: filler
+Luminous Leaf Pendant: filler
+Grenade of Peaceful Destruction: filler
+Morel of Immortality: filler
+Hyperdrive Hair Dryers: filler
+Glimmering Gemstone Necklace: filler
+Rocket Fuel for Your Car: filler
+Flax Seed of Cotton Softness: filler
+Spicy Chili Sauce of Doom: filler
+Hazelnut of Gigantic Tininess: filler
+Cloak of Camouflage in Plain Sight: filler
+Moonwhisper Dagger: filler
+Wyrmclaw Claws: filler
+Sneeze of Wisdom: filler
+Emberstone Staff: filler
+Unstable Time Machine: filler
+Superpowered Sushi Roll: filler
+Super-Sized Squirt Gun: filler
+Bouncy Castle of Defense: filler
+Eternity's Edge Longsword: filler
+Stormcaller's Horn: filler
+Squishy Robot Remote: filler
+Emberstone Amulet: filler
+Sassy Squirt Gun: filler
+Invisibility Cloak (Almost): filler
+Disorienting Disco Ball: filler
+Galactic Guitar Solo: filler
+Emberwing Brooch: filler
+Windsong Quiver: filler
+Iridescent Wings: filler
+Glowing Grappling Hook: filler
+Shadowstep Boots: filler
+Shattered Mirror of Self-Doubt: filler
+Cowbell of Power: filler
+Stinky Sock Amulet: filler
+Flying Pizza Cutter: filler
+Magic Beans: filler
+Furry Feather Boa of Charm: filler
+Turnip of Graceful Clumsiness: filler
+Goblet of Spilled Drinks: filler
+Aetherial Amulet of Wisdom: filler
+Emberwing Cloak: filler
+Stormsurge Staff of Elemental Control: filler
+Pocket Portal to the Beach: filler
+Jubilant Jelly Filled Jaws: filler
+Celestial Map Scroll: filler
+Dwarven Iron Fist Gauntlets: filler
+Caffeine Boost: filler
+Bouncing Bubble Wrap: filler
+Mythril Chainmail Hauberk: filler
+Whispering Walls Cloak: filler
+Fumbling Flare Gun: filler
+Blueberry of Red Hues: filler
+Unstable Element: filler
+Forgotten Fancy Shoes: filler
+Avocado of Rapid Ripening: filler
+Infinite Coffee Refill: filler
+Alien Abductee's Briefcase: filler
+Pepperbush of Soothing Coolness: filler
+Chrysanthemum of Petal Shedding: filler
+Crazy Cereal Box: filler
+Automatic Pencil Sharpener: filler
+Gooseberry of Feather Plucking: filler
+Battleaxe of the Ancients: filler
+Papaya of Blandness Induction: filler
+Spellbound Quiver of Arrows: filler
+Orchid of Easy Cultivation: filler
+Spoon of Soup Splashing: filler
+Frosty Focus Crystal: filler
+Kitten Fuzz Boots: filler
+Fiery Focus Lens: filler
+Luminous Lance of Justice: filler
+Boots of Moonwalking: filler
+Instant Coffee IV: filler
+Mysterious Cheese Cubes: filler
+Corn of Butter Melting: filler
+Pocket Lint Generators: filler
+Squirt Gun of Silliness: filler
+Giggle Juice Grenade: filler
+Luminous Lantern Shield: filler
+Ancient Oracle Amulet: filler
+Secret Identity Belt Buckle: filler
+Wyrmguard Shield: filler
+Bubblewrap Battering Ram: filler
+Emberclaw Dagger: filler
+Golden Amulet of the Ancients: filler
+Giant Hamster Wheel of Energy: filler
+Raven's Wing Boots: filler
+Fiery Fury Dagger: filler
+Kitten Mittens of Warmth: filler
+Wyrmwood Staff: filler
+Cheeto Dust Grenade: filler
+Forgotten Recipe: filler
+Inflatable Swordfish: filler
+Bubble Wrap Briefcase: filler
+Bouncing Bouncy Castle Helmet: filler
+Golden Chalice of the Elements: filler
+Spellbound Boots: filler
+Celestial Chalice of Clarity: filler
+Disco Ball Dampener: filler
+Ancient Rune of Protection: filler
+Shovel of Dirt Creation: filler
+Overcooked Pancakes: filler
+Golden Griffin Feather: filler
+Celestial Quiver of the Divine: filler
+Whispering Winds Boots: filler
+Nightshade Gauntlets: filler
+Barberry of Hairless Thorns: filler
+Enchanted Elixir of Empowerment: filler
+Silly Squirt Gun: filler
+Snacktastic Food Carton: filler
+Automatic Answering Machines: filler
+Kitten Camouflage: filler
+Randomizer Ray Gun: filler
+Inflatable Ink Bottles: filler
+Fuzzy Sock of Fortune: filler
+Lichwood Cane: filler
+Cactus Juice: filler
+Bucket of Dehydrated Water: filler
+Whispering Walls Tome: filler
+Fuzzy Boots of Doom: filler
+Dragonheart Pendant: filler
+Shadowstalker Boots: filler
+Tenebrous Gauntlets: filler
+Lucky Breaker: filler
+Furry Boots: filler
+Randomized Pizza Delivery: filler
+Moonwhisper's Tear: filler
+Unstable Egg Cartons: filler
+Shadowfire Pistol: filler
+Golden Gryphon Figurine: filler
+Bedroll of Sleepless Nights: filler
+Luminous Leaf Amulet: filler
+Shadow Walker Boots: filler
+Thunderbolt Arrow: filler
+Runebound Boots of Speed: filler
+Rune of the Ancients: filler
+Intergalactic Toast Dispenser: filler
+Magnifying Glass of Tunnel Vision: filler
+Cashew of Priceless Cheapness: filler
+Radiant Ring of Protection: filler
+Strawberry of Allergic Reactions: filler
+Thunderforged Hammer: filler
+Squid of Inky Cleanliness: filler
+Dragonfire Sword: filler
+Loyal Loyalty Token: filler
+Phoenix Feather Quill: filler
+Golden Chalice of Strength: filler
+Unlucky Lucky Charm: filler
+Ruby Slippers: filler
+Mythril Mask of Mystery: filler
+Sassy Sunglasses of Coolness: filler
+Sonic Squeaker Amulet: filler
+Alien Abduction Insurance: filler
+Turbo Toilet Brush: filler
+Golden Chalice of the Ancients: filler
+Fuzzy Logic Fragment: filler
+Huckleberry of Gigantism: filler
+Raven's Wing Shield: filler
+Celestial Compass of the Wayfinder: filler
+Wizard's Staff of Power: filler
+Starlight Seraphim Ring: filler
+Pillow of Neck Discomfort: filler
+Spicy Taco Tuesday: filler
+Elemental Quencher Potion: filler
+Shadow Dancer's Cloak: filler
+Fae Cloak: filler
+Golden Toilet Brush: filler
+Dragonheart Amulet: filler
+Aetherwhisper Cloak: filler
+Emberheart Shield: filler
+Quirky Quest Crystal: filler
+Caffeine-Infused Combat Boots: filler
+Stormsurge Gauntlets: filler
+Lucky Coin Flipper: filler
+Luminous Lasso of Truth: filler
+Infinite Bouncy Balls: filler
+Pogo Stick of Agility: filler
+Golden Gauntlets of Strength: filler
+Nightshade Blade: filler
+Space S'mores Kit: filler
+Donut of Life: filler
+Celestial Compass of Orientation: filler
+Moonwhisper Amulet: filler
+Disco Ball Deflecto: filler
+Giggly Giggle Juice: filler
+Thunderbolt Boots: filler
+Shadowfire Dagger: filler
+Mythril Mace of Might: filler
+Pogo Stick Propulsion System: filler
+Celestial Crown of Glory: filler
+Fuzzy Frenzy Cape: filler
+Dragon's Tooth Sword: filler
+Time Traveler's Guidebook: filler
+Inflatable Unicorn: filler
+Sonic Screwdriver Wrench: filler
+Almond of Bitter Sweetness: filler
+Mystic Mirror of Mirth: filler
+Bubblegum Shield Potion: filler
+Bizarre Dreamcatcher Amulet: filler
+Snurfle Juice: filler
+Dreamweaver's Loom: filler
+Spinning Top Grenade: filler
+Mythril Medallion of Courage: filler
+Feather Duster of Flight: filler
+Shadowfire Elixir: filler
+Rocket Fuelled Donuts: filler
+Mischief Maker's Wand: filler
+Bubble Tea Tonic: filler
+Glimmerglass Dagger: filler
+Wheat of Gluten-Free Allergies: filler
+Funky Monkey of Agility: filler
+Disguise-a-Mask: filler
+Inferno's Fury Shield: filler
+Rope of Entangling Freedom: filler
+The Sword of Pacifism: filler
+Whispering Winds Ring: filler
+Fern of Cold Resistance: filler
+Feather Boa of Flight: filler
+Disguise Me Now!: filler
+Quantum Pizza Cutter: filler
+Giant Hamster Wheel: filler
+Golden Gryphon Statue: filler
+Bouncing Ball of Confusion: filler
+Shadowdance Duster: filler
+Phantom Pogo Stick: filler
+Superhero Cape Linings: filler
+Sneeze Powder Grenade: filler
+Whispersilk Rope: filler
+Luminous Loom Fabric: filler
+Fiery Fang Gauntlets: filler
+Automatic Hug Dispenser: filler
+Dreamcatcher's Journey: filler
+Fiery Fable Tome: filler
+Fancy Fuzzy Fingerless Gloves: filler
+Cosmic Cane Toad: filler
+Zombie Zucchini Fries: filler
+Moonwhisper: filler
+Apple of Gravity Defiance: filler
+Shadowglow Elixir: filler
+Dragon's Claw Ring: filler
+Spinning Top of Confusion: filler
+Gravity Boots for Cats: filler
+Flying Pizza Crusts: filler
+Golden Donut Shield: filler
+Time Traveler's Tea Kettle: filler
+Starlight Amulet: filler
+Quantum Quail Queen Crown: filler
+Crystal Censer Vial: filler
+Glimmering Gossamer Cloak: filler
+Overly Complex Calculators: filler
+Dragon's Tooth Shield: filler
+Mithril Shield: filler
+Enchanted Earring of Clarity: filler
+Furry Muffin Top of Warmth: filler
+Emberfist Mace: filler
+Riverstone Focus: filler
+Wyrm's Tooth Necklace: filler
+Ninja Stars: filler
+Silly Slingshot of Truth: filler
+Overly Attached Bear Claw: filler
+Starlight Seraph's Tear: filler
+Self-Aware AI Coffee Mug: filler
+Arcane Quiver: filler
+Protractor of Doom: filler
+Bomb of Careful Explosions: filler
+Invisible Cloak: filler
+Shadowfire Gloves: filler
+Sonic Sauce Pack: filler
+Lucky Coinpurse: filler
+Inflatable Shield: filler
+Infinite Loop Necklace: filler
+Dreamcatcher Necklace: filler
+Ancient Oakwood Staff: filler
+Fuzzy Slippers of Stealth: filler
+Frostbite Chariot: filler
+Thunderous Boots of Speed: filler
+Ninja Noodle Gun: filler
+Ethereal Eclipse Orb: filler
+Pocket-sized Black Hole: filler
+Jellybean Jester's Hat: filler
+Golden Golem Amulet: filler
+Helmet of Hindsight: filler
+Celestial Chronicle Book: filler
+Eldritch Eye of Insight: filler
+Aetherial Boots of Speed: filler
+Dragonfire Earrings: filler
+Mirage Crystal Orb: filler
 Glowing Mushroom Ring: filler
+Overpriced Ocarina of Wisdom: filler
+Fuzzy Logic Fingerless Gloves: filler
+Whisperwood Staff: filler
+Unstable Time Travel Device: filler
+Inflatable Sword: filler
+Lingonberry of Tongue-Tying: filler
+Turbocharged Toilet Plunger: filler
+Ancient Forest Crown: filler
+Electric Guitar of Justice: filler
+Icy Tombstone Totem: filler
+Golden Goose Egg: filler
+Quantum Toast Dispenser: filler
+Algae of Dehydration: filler
+Fuzzy Fart Gun: filler
+Cloudberry of Gravitational Defiance: filler
+Shadowheart Dagger: filler
+Giant Spaghetti Monster: filler
+Thunderfist Torque of Thunder: filler
+Arcane Crystal Focus: filler
+Dreamcatcher's Web of Illusions: filler
+Flameheart Shield: filler
+Flappy Wings: filler
+Jellybean Grenade: filler
+Starlight Crystal of Purification: filler
+Sceptre of the Elements: filler
+Fiendfetter's Boots: filler
+Jubilant Jelly Roll: filler
+Sparkle Bomb: filler
+Bubble Wrap of Bliss: filler
+Celestial Shield: filler
+Dragon's Breath Potion: filler
+Flying Monkey Cape: filler
+Vial of Luminous Essence: filler
+Whispering Winds Necklace: filler
+Inflatable Hamster Wheel: filler
+Quack Attack Helm: filler
+Disco Fever Boots: filler
+Emberwood Bow: filler
+Runebound Tome: filler
+Golden Chariot Saddle: filler
+Scroll of Illiterate Wisdom: filler
+Spicy Taco of Life: filler
+Elven Armband of Wisdom: filler
+Scallop of Rough Smoothness: filler
+Pixelated Pizza Slices: filler
+S'mores Rocket: filler
+Mushroom of Shrinking: filler
+Furry Feline Shield: filler
+Corgi Whisperer's Collar: filler
+Astral Lasso of the Cosmos: filler
+Bouncy Castle Armor: filler
+Runestone Axe: filler
+Jolly Jelly Donut Jar: filler
+Fireheart Gauntlets: filler
+Ironwood Longbow: filler
+Lucky Llama Luck Charm: filler
+Laser Guided Toast: filler
+Golden Chalice of Life and Vitality: filler
+Random Sentence Generator: filler
+Raven's Quill: filler
+Runestone of Resilience: filler
+Grappling Hook of Downward Ascent: filler
+Shapeshifter's Tome: filler
+Mirage Cloak Pin: filler
+Broomstick of Flying: filler
+Bouncy Ball Shield: filler
+Perpetually Empty Quiver of Infinite Capacity: filler
+Shiny Shark Tooth Necklace: filler
+Potato of French Fry Sprouting: filler
+Flying Pizza Toss: filler
+Wyrmheart Gauntlets: filler
+Infinite Loop of Laughter: filler
+Crystal Cove Amulet: filler
+Ironwood Axe of the Wild: filler
+Mangosteen of Enlargement: filler
+Peanut of Nutless Shells: filler
+Tickle Me Trinket: filler
+Luminous Leaf Cloak: filler
+Gloves of Butterfingers: filler
+Enoki of Tangled Straightness: filler
+Begonia of Sunlight Aversion: filler
+Shadowweave Cloak: filler
+Frostbite Cloak: filler
+Quantum Leapfrogging Boots: filler
+Zany Zen Master: filler
+Onion of Tear Prevention: filler
+Elixir of Sober Drunkenness: filler
+Wildfire Wyrm Scale Shield: filler
+Broccoli of Tree Impersonation: filler
+Bouncy Castle of Chaos: filler
+Inflatable Hammer: filler
+Shiny Socks of Doom: filler
+Fuzzy Waffle Disks: filler
+Grapefruit of Tiny Hugeness: filler
+Golden Gaze Helmet: filler
+Quantum Coffee Mug: filler
+Portal Gun Pizza Cutter: filler
+Rambutan of Hairless Fuzziness: filler
+Sunflower Seed of Moonlight Absorption: filler
+Mithril Mail Coif: filler
+Moonwhisper Boots: filler
+Vesper's Tear Earrings: filler
+Lucky Socks of Doom: filler
+Axe of Gentle Woodcutting: filler
+Dinosaur Costume of Camouflage: filler
+Quantum Quiche Cutters: filler
+Crystal Oracle Focus: filler
+Pogo Stick Polearm: filler
+Sparkle Snake Oil: filler
+Golden Griffin Feather Quill: filler
+Elven Elixir of Endurance: filler
+Space Suit for Cats: filler
+Gassy Gas Mask: filler
+Celestial Luminari Lantern: filler
+Arcane Tome of Knowledge: filler
+Enchanted Compass: filler
+Electric Toothbrush: filler
+Mystic Oracle's Scrying Stone: filler
+Fuzzy Boots of Agility: filler
+Charm of Unlucky Luck: filler
+Quantum Coffee: filler
+Virtual Voodoo Dolls: filler
+Shadowfire Torc: filler
+Gardenia of Stench Emission: filler
+Map of Unknown Locations: filler
+Orange of Citrus Aversion: filler
+Dragonheart Shield of Courage: filler
+Moonflower Elixir: filler
+Spellbound Mirror: filler
+Starheart Choker: filler
+Golden Chalice of Light: filler
+Featherfall Cloak: filler
+Elemental Amulet of Balance: filler
+Mysterious Pocketwatch: filler
+Giant Squid Gloves: filler
+Disco Ball of Teleportation: filler
+Ring of Invisible Bling: filler
+Ancient Atlas of the Cosmos: filler
+Luminous Scepter: filler
+Flameheart Sword: filler
+Aetherial Amulet of Accuracy: filler
+Glitter Bomb of Annoyance: filler
+Forgotten Lunchbox of Wonder: filler
+Disco Ball of Distraction: filler
+Wildwood Staff: filler
+Strangled Whisper: filler
+Golden Giggle Potions: filler
+Crystal Orb of Divination: filler
+Starlight Serpentscale Armor: filler
+Wyrmfist Gauntlets: filler
+Forgotten Relic: filler
+Celestial Sling: filler
+Intergalactic Ping Pong Ball: filler
+Disoriented Diving Gear: filler
+Jasmine of Odorless Flowers: filler
+Whispering Cloak: filler
+Belt of Loosening Tightness: filler
+Invisible Invisibility Cloak: filler
+Sassy Sock Drawer Boots: filler
+Ancient Oak Shield: filler
+Verdant Vial of Vitality: filler
+Enchanted Forest Ring: filler
+Starlight Serenade Instrument: filler
+Spicy Mustache Wax: filler
+Whispering Windsong Cloak: filler
+Joke Jar of Jelly Beans: filler
+Golden Griffin Amulet: filler
+Spaghetti Western Whip: filler
+Giggle Juice Bottle: filler
+Embersteel Sword: filler
+Unstable Stool of Uncertainty: filler
+Feathered Crown: filler
+Time Warp Toilet Brushes: filler
+Celestial Sword of Justice: filler
+Bubblegum Bulletproof Vest: filler
+Misty Meadowbrook Boots: filler
+Wyrmshield Amulet: filler
+Rocking Chair of Invisibility: filler
+Arcane Amulet of Clarity: filler
+Sassy Sock Puppet: filler
+Fishing Rod of Fish Repellent: filler
+Radish of Slowness Enhancement: filler
+Tinderbox of Dampness: filler
+Aurora Cloak: filler
+Moonstone Scepter: filler
+Enchanted Quill of Knowledge: filler
+Miracle Fruit of Sour Enhancement: filler
+Partridgeberry of Fowl Repulsion: filler
+Quirky Quantum Cubes: filler
+Banana Peel Grenade: filler
+Runekeeper's Boots: filler
+Caffeine Surgeon: filler
+Furry Feline Fancy Hat: filler
+Sunny Side Up Spoon: filler
+Wyrmfire Amulet: filler
+Luminous Lantern of Light: filler
+Hammer of Delicate Smashing: filler
+Snail's Trail: filler
+Bubble Wrap: filler
+Lucky Socks: filler
+Soybeans of Meat Cravings: filler
+Sparkly Sock Drawer Surprise: filler
+Shadowdance Cloak: filler
+Bungee Cord of Balance: filler
+Wyrmstalker's Sword: filler
+Super Snack Pack: filler
+Dewberry of Dehydration: filler
+Dragonstone Amulet: filler
+Elven Bowstring: filler
+Squirrel Nutmeg of Distraction: filler
+Camellia of Rapid Shedding: filler
+Starlight Seren's Song Crystal: filler
+Frostfire Flare Gun: filler
+Forgotten Password Cracker: filler
+Quantum Fuzzy Socks: filler
+Peach of Fuzzy Baldness: filler
+Fiery Ember Sword: filler
+Spaghetti Sauce of Power: filler
+Dreamcatcher's Quest: filler
+Intergalactic Instant Ramen: filler
+Inscrutable Ice Cream Cone: filler
+Joke Shop Jester's Jester: filler
+Giggle Water Geyser: filler
+Enchanted Elixir of Strength: filler
+Moonwhisper Scroll: filler
+Infinite Ink Pens: filler
+Mysterious Marshmallow Treats: filler
+Fiery Wyrm Fang: filler
+Armor of Vulnerable Invincibility: filler
+Star-Crystal Chalice: filler
+Fiery Fusion Amulet: filler
+Chaos Theory Coffee Mug: filler
+Ninja Starfish Cape: filler
+Invisibility Pants: filler
+Elemental Seal Set: filler
+Starlight Salad Tongs: filler
+Super Sneeze Spray Gun: filler
+Infinite Sushi Plate: filler
+Shadowfire Amulet: filler
+Kiwi of Hairless Fuzziness: filler
+Bizarre Bubble Wrap: filler
+Sneaky Boots: filler
+Bubblegum Shield: filler
+Hyperactive Hamster Wheel: filler
+Fiery Focus Crystal: filler
+Pizza Shield: filler
+Golden Acorn Pendant: filler
+Stone of Despair: filler
+Frostbiter Axe: filler
+Mulberry of Rapid Decomposition: filler
+Retro Video Game Controller: filler
+Glowing Gummy Worms: filler
+Quantum Cookies: filler
+Runebound Shield: filler
+Embersteel Gauntlets: filler
+Cosmic Toaster Oven: filler
+Fuzzy Dice: filler
+Gilded Cage of Freedom: filler
+Wyrmshield Gauntlets: filler
+Bubble Gum Bubble Shield: filler
+Donut of Many Flavors: filler
+Glimmerglaive Sword: filler
+Arcane Crystal Orb: filler
+Disco Ball of Deception: filler
+Runekeeper's Axe: filler
+Firecrystal Pendant: filler
+Jackfruit of Lightness Enhancement: filler
+Lunar Lasso of Light: filler
+Wintergreen Berry of Summer Sprouting: filler
+Crystal Oracle's Orb: filler
+Mistweaver Cloak: filler
+Enchanted Quill of Truth: filler
+Pencil Eraser Helm: filler
+Fiery Fury Helm: filler
+Lentils of Slowness Inducement: filler
+Spicebush of Mildness Induction: filler
+Disco Dance Shoes: filler
+Flickering Flame Wand: filler
+Chokeberry of Smooth Swallowing: filler
+Dreamcatcher's Scepter: filler
+Phantom Fury Boots: filler
+Glowing Amulet of Health: filler
+Thunderbolt Gauntlets: filler
+Golden Gorgon Helm: filler
+Celestial Sphere of Protection: filler
+Nightshade Potion: filler
+Golden Bacon Slicer: filler
+Fig of Seedless Reproduction: filler
+Celestial Crown Jewel: filler
+Emberheart's Blessing: filler
+Glittery Gun of Confusion: filler
+Pocket Lint Blasters: filler
+Dragonheart Shield: filler
+Dragon Fruit of Fire Breathing Impairment: filler
+Instantly Forgettable Memory: filler
+Banana of Slippery Peels: filler
+Pogo Stick: filler
+Flying Carpet Ride: filler
+Wildfire Boots: filler
+Fiery Focus Ring: filler
+Krazy Kite Shield: filler
+Fiddlehead Feathered Hat: filler
+Emberflame Shield: filler
+Celestial Crown of Justice: filler
+Mug of Sobering Ale: filler
+Robot Uprising Kit: filler
+Spellbound Quiver: filler
+Intergalactic Jelly Donut: filler
+Torch of Cold Illumination: filler
+Laser Pointer Rifle: filler
+Instant Gratification Button: filler
+Ancient Tome of Wisdom: filler
+Rocket Fuel Caffeine Pills: filler
+Automatic Dog Treat Dispenser: filler
+Unlikely Unicorns' Tears: filler
+Bouncy Castle: filler
+Thunderbolt Rod: filler
+Spaghetti of Doom: filler
+Celestial Compass of Direction: filler
+Shadowforged Dagger: filler
+Thunderfist Boots: filler
+Flying Pineapple Launcher: filler
+Poppy of Wakefulness Induction: filler
+Sparkly Tiara Helmet: filler
+Flameheart Helm: filler
+Fuzzy Boots of Fearlessness: filler
+Golden Gryphon Staff: filler
+Pogo Stick Legs: filler
+Interdimensional Ice Cream: filler
+Enchanted Feather of Flight: filler
+Magic Marker of Chaos: filler
+Emberwood Staff: filler
+Disco Ball of Truth: filler
+Wyrmweaver's Loom: filler
+Whispering Oak Staff: filler
+Space Station S'mores Kit: filler
+Ninja's Favorite Scarf: filler
+Jelly Bean Jaunt: filler
+Icy Illusion Cloak: filler
+Randomly Generated Rations: filler
+Ninja Pajamas: filler
+Hops of Sleepiness Induction: filler
+Rose of Thornless Stems: filler
+Glimmering Elixir: filler
+Fae Feather Quiver: filler
+Ethereal Elixir Flask: filler
+Giddy Giraffe Antlers: filler
+Eyes of Evasion: filler
+Zany Zipper Pouch: filler
+Inflatable Sumo Suit: filler
+Shiny Coin Purse: filler
+Infinite Scroll Scrolls: filler
+Enchanted Quiver: filler
+Rocket Fuel for Cats: filler
+Wolfberry of Sheep Attraction: filler
+Crystal Orb of Clarity: filler
+Robot Buttermilk Biscuit Maker: filler
+Ironwood Cudgel of Justice: filler
+Lion's Mane of Cowardice: filler
+Wyrmwrath's Fury: filler
+Laser Pointer of Destiny: filler
+Cheese of Odorless Stench: filler
+Rocket Fuel Fries: filler
+Electric Sheep Amulet: filler
+Cursed Coffee Mug: filler
+Raspberry of Silent Whistling: filler
+Space Helmet of Doom: filler
+Invisibility Cloak of Attention-Seeking: filler
+Explosive Egg Salad: filler
+Darkfire Chalice: filler
+Spinning Top Hat of Strategy: filler
+Sparkly Sock Drawer: filler
+Pocket Lint Storage: filler
+Snowberry of Heat Emission: filler
+Bubble Wrap of Regeneration: filler
+Shadowfire Cloak: filler
+Banana Peel Bomb: filler
+Celestial Songstone: filler
+Captain's Fancy Hat: filler
+Wyrmguard Gauntlets: filler
+Fiery Pizza Topping Dispensers: filler
+Golden Giggle Powder: filler
+Magnolia of Rapid Wilting: filler
+Chicken Wing Shield: filler
+Banana Peel Boots: filler
+Flibberjibit Boots: filler
+Fishin' For Trouble Rod: filler
+Net of Fish Liberation: filler
+Serviceberry of Disservice: filler
+Quantum Leapfrog: filler
+Midnight Miracles Necklace: filler
+Invisible Ink Fountain Pen: filler
+Robot Tears: filler
+Space Toaster: filler
+Dragon's Breath Elixir: filler
+Frosty Fjord Pickaxe: filler
+Celestial Amulet: filler
+Randomly Selected Cat Video: filler
+Silly Sock Drawer: filler
+Soursop of Sweetness Amplification: filler
+Silly Sock Puppet: filler
+Laser Pointer Wand: filler
+Windsong Cloak: filler
+Golden Gryphon Helmet: filler
+Party Horn: filler
+Pogo Stick Shield: filler
+Furry Socks of Confusion: filler
+Celestial Starseeker: filler
+Fanciful Fusion Fuel Cells: filler
+Bread of Rock Hardness: filler
+Pizza Cutter: filler
+Vortex Amulet: filler
+Quiche of Power: filler
+Tofu of Texture Confusion: filler
+Whispering Winds Horn: filler
+Stuffed Animal Squad: filler
+Frostbite Choker: filler
+Wand of Unintentional Magic: filler
+Jellyfish Jester Hat: filler
+Bungee Jumping Boots: filler
+Whispering Windsong Quiver: filler
+Luminous Robes: filler
+Enchanted Quiver of Arrows: filler
+Robo-Pineapple Shield: filler
+Mithril Chalice: filler
+Wildfire Tome of Spells: filler
+Cosmic Cream Filled Donut: filler
+Banana Peel Band-Aid: filler
+Reality Check Rations: filler
+Golden Gryphon's Horn: filler
+Maelstrom Amulet of Turmoil: filler
+Mystery Meat of the Gods: filler
+Golden Gargoyle's Tear: filler
+Celestial Boots: filler
+Dreamcatcher Amulet: filler
+Quantum Leap Frog Legs: filler
+Mysterious Map Tiles: filler
+Pocket Portal to Nowhere: filler
+Palm of Cold Resistance: filler
+Moonwhisper's Horn: filler
+Gravity-Defying Furry Slippers: filler
+Fuzzy Feather Boots: filler
+Laser-Engraved Pinecones: filler
+Instant Tan Spray: filler
+Robot Uprising Ring: filler
+Wildfire Wyrm Tooth Amulet: filler
+El'goroth's Eternal Eye of Insight: filler
+Robot Uprising Serum: filler
+Wyrmwood Shield: filler
+Unstable Sauce Pack: filler
+Ninja Boots: filler
+Astral Crown of Wisdom: filler
+Coral of Dullness Enhancement: filler
+Aetherium Helm: filler
+Cauliflower of Vegetable Disguise: filler
+Boots of Graceful Stumbling: filler
+Spicy Taco of Power: filler
+Ninja Nose Guard: filler
+Celestial Chalice of Healing: filler
+Fuzzy Boots: filler
+Dragon's Scale Belt: filler
+Disco Ball Gun: filler
+Fiery Gauntlets: filler
+Luminous Lantern of Illumination: filler
+Explosive Potted Plant: filler
+Invisibility Cream (Expired): filler
+Super Soaker Squirt Gun: filler
+Shadowglow Amulet: filler
+Unhinged Jokester's Jester Hat: filler
+Mithril Axe: filler
+Quirky Quantum Gloves: filler
+Iris of Blindness Induction: filler
+Emberstone Shield: filler
+Lucky Leaf of Fortune: filler
+Cosmic Coffee Mug: filler
+Shadowstep Boots of Stealth: filler
+Shadowfire Scepter of Darkness: filler
+Ninja Sneakers: filler
+Whispered Words of Wisdom: filler
+Whispers of Wisdom: filler
+Shadowfire Arrow: filler
+Emberheart Choker: filler
+Starsteel Sword Hilt: filler
+Tinfoil Crown: filler
+Grimoire of Cheerful Necromancy: filler
+Furry Feline Companion: filler
+Starry Night Starlight Scope: filler
+Intergalactic Coffee Mug: filler
+Super Soaker of Water: filler
+Dragonfire Ring: filler
+Thunderclaw Helm: filler
+Infinite Socks Generator: filler
+Dragonheart Shield Bearer: filler
+Anemone of Wind Resistance: filler
+Pogo Stick of Life: filler
+Random Item Generator: filler
+Superfluous Sausage Ring: filler
+Luminous Lollipop Gun: filler
+Golden Toaster of Wisdom: filler
+Banana Peels: filler
+Ancient Rune Scroll: filler
+Lizard's Scale: filler
+Ancient Tome of Spells: filler
+Phoenix Feather Shield: filler
+Jolly Jelly Bean Jetpack: filler
+Quarky Questing Crystal: filler
+Oracle's Eye Amulet: filler
+Ancient Atlas Scroll: filler
+Rhododendron of Shrinking Flowers: filler
+Azure Oracle's Prophecy Scroll: filler
+Luminous Cloak: filler
+Crazy Sauce: filler
+Golden Sun Chariot: filler
+Unlucky Coin: filler
+Unstable Elixir: filler
+Golden Griffin Talon: filler
+Nightshroud Cloak: filler
+Windsong Boots: filler
+Bubble Wrap Box: filler
+Waterskin of Dehydration: filler
+Arrows of Boomerang Trajectory: filler
+Fiery Fusion Sword: filler
+Enchanted Quiver of El'goroth: filler
+Ancient Tome of Shadows: filler
+Baffling Bubble Wrap: filler
+Infinite Pizza Party Pass: filler
+Moonwhisper Staff: filler
+Mythic Scepter: filler
+Intergalactic Ice Cream Cones: filler
+Runestone of Power: filler
+Furry Friend Amulet: filler
+Chickpeas of Chicken Impersonation: filler
+Helmet of Selective Deafness: filler
+Pixie Pogo Stick: filler
+Emberheart Amulet: filler
+Self-Aware AI Chip: filler
+Nightshade Tome: filler
+Disco Ball of Doom: filler
+Ember's Fury: filler
+Tome of the Ancients' Lore: filler
+Celestial Chainmail Armor: filler
+Celestia's Tear Necklace: filler
+Sock Drawer Key: filler
+Bizarre Bubblegum Shield: filler
+Juniper Berry of Flower Blooming: filler
+Cremini of Burning Coldness: filler
+Fiery Essence Vial: filler
+Moonstone Chalice: filler
+Acorn of Tree Planting: filler
+Emberforge Sword: filler
+Thunderbolt Shield: filler
+Randomness Generator: filler
+Emberstone Boots: filler
+Fuzzy Boots of Speed: filler
+Mysterious Moleskine Notes: filler
+Frostborn Battlestaff: filler
+Unstable Unicorn Horn: filler
+Golden Gryphon's Tear Earring: filler


### PR DESCRIPTION
I made a script to import manuals dropped in the new input folder.
Originally I wasnt planning to include it but I felt that it could help other people.
its not perfect, if a manual uses hooks to import/create/modify items those changes wont get imported.
it is useful for the basic manuals with way too many items. _stare at warehouse_

To make it better, I would need to run each world's create_items but thats not something I know how do to from a simple script.

I just noticed I left in the print("wow") for my debug breakpoint... I probably wont make a commit just to fix that.