### PR TITLE
Mark Red Tea as Progression (FireRed/LeafGreen)

### DIFF
--- a/worlds/Pokemon FireRed and LeafGreen/progression.txt
+++ b/worlds/Pokemon FireRed and LeafGreen/progression.txt
@@ -211,7 +211,7 @@ Razz Berry: filler
 Red Flute: filler
 Red Scarf: filler
 Red Shard: filler
-Red Tea: unknown
+Red Tea: progression
 Repeat Ball: filler
 Repel: filler
 Retro Mail: filler


### PR DESCRIPTION
Red Tea from Pokemon FireRed/LeafGreen was not marked as progression