### PR TITLE
Fix Helix Fossil and Evolution Stones (FireRed and LeafGreen)

### DIFF
--- a/worlds/Pokemon FireRed and LeafGreen/progression.txt
+++ b/worlds/Pokemon FireRed and LeafGreen/progression.txt
@@ -68,7 +68,7 @@ Exp. Share: useful
 Fab Mail: filler
 Fame Checker: filler
 Figy Berry: filler
-Fire Stone: useful
+Fire Stone: progression
 Five Pass: progression
 Fluffy Tail: filler
 Fly Celadon City: progression
@@ -118,7 +118,7 @@ Harbor Mail: filler
 Hard Stone: unknown
 Heal Powder: filler
 Heart Scale: filler
-Helix Fossil: useful
+Helix Fossil: progression
 Hideout Key: progression
 Hondew Berry: filler
 Hyper Potion: filler
@@ -131,7 +131,7 @@ King's Rock: useful
 Lansat Berry: filler
 Lava Cookie: filler
 Lax Incense: filler
-Leaf Stone: useful
+Leaf Stone: progression
 Leftovers: useful
 Lemonade: filler
 Leppa Berry: filler
@@ -163,7 +163,7 @@ Metal Powder: unknown
 Meteorite: progression
 Miracle Seed: unknown
 Moomoo Milk: filler
-Moon Stone: useful
+Moon Stone: progression
 Mystic Ticket: progression
 Mystic Water: unknown
 Nanab Berry: filler
@@ -252,7 +252,7 @@ Star Piece: filler
 Stardust: filler
 Starf Berry: filler
 Stick: unknown
-Sun Stone: filler
+Sun Stone: progression
 Super Potion: filler
 Super Repel: filler
 Super Rod: progression
@@ -312,7 +312,7 @@ Teachy TV: filler
 Thick Club: unknown
 Three Pass: progression
 Thunder Badge: progression
-Thunder Stone: filler
+Thunder Stone: progression
 Timer Ball: filler
 Tiny Mushroom: filler
 Town Map: useful
@@ -324,7 +324,7 @@ Ultra Ball: filler
 Up-Grade: useful
 Volcano Badge: progression
 Vs. Seeker: useful
-Water Stone: filler
+Water Stone: progression
 Watmel Berry: filler
 Wave Mail: filler
 Wepear Berry: filler


### PR DESCRIPTION
The evolution stones and Helix Fossil were misclassified as useful/filler.
FireRed and LeafGreen considers these items as Progression.